### PR TITLE
Fix: Apply the .env behavior to the code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@openrouter/ai-sdk-provider": "6.0.0-alpha.1",
         "ai": "^6.0.40",
+        "dotenv": "^17.2.3",
         "zod": "^4.3.5"
       },
       "devDependencies": {
@@ -837,6 +838,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
-    "ai": "^6.0.40",
     "@openrouter/ai-sdk-provider": "6.0.0-alpha.1",
+    "ai": "^6.0.40",
+    "dotenv": "^17.2.3",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import 'dotenv/config';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { openrouter } from '@openrouter/ai-sdk-provider';


### PR DESCRIPTION
- Install dotenv package to load environment variables from .env file
- Add 'dotenv/config' import at the top of index.ts
- Now npm start correctly loads .env configuration as documented in README